### PR TITLE
Integrate joint limiter to MAC

### DIFF
--- a/multi_time_trajectory_controller/include/multi_time_trajectory_controller/multi_time_trajectory_controller.hpp
+++ b/multi_time_trajectory_controller/include/multi_time_trajectory_controller/multi_time_trajectory_controller.hpp
@@ -160,7 +160,6 @@ protected:
 
   using JointLimiter = joint_limits::JointLimiterInterface<joint_limits::JointLimits>;
   std::shared_ptr<pluginlib::ClassLoader<JointLimiter>> joint_limiter_loader_;
-  // TODO(bijoua29): change below to std::vector of the same
   std::unique_ptr<JointLimiter> joint_limiter_;
 
   // Timeout to consider commands old

--- a/multi_time_trajectory_controller/src/trajectory.cpp
+++ b/multi_time_trajectory_controller/src/trajectory.cpp
@@ -29,6 +29,7 @@
 #include "hardware_interface/macros.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/time.hpp"
+#include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 
 namespace multi_time_trajectory_controller
 {
@@ -39,6 +40,40 @@ namespace
 constexpr double DEFAULT_MAX_VELOCITY = 1.5;      // rad/s
 constexpr double DEFAULT_MAX_ACCELERATION = 5.0;  // rad/s^2
 constexpr double DEFAULT_MAX_JERK = 200.0;        // rad/s^3
+
+// convert JointTrajectoryPoint to vector of AxisTrajectoryPoint
+void convert_to_axis_trajectory_points_for_joint_limiting(
+  const trajectory_msgs::msg::JointTrajectoryPoint & joint_trajectory_point,
+  std::vector<control_msgs::msg::AxisTrajectoryPoint> & axis_trajectory_points)
+{
+  for (size_t i = 0; i < joint_trajectory_point.positions.size(); ++i)
+  {
+    axis_trajectory_points[i].position = joint_trajectory_point.positions[i];
+    axis_trajectory_points[i].velocity = joint_trajectory_point.velocities[i];
+    axis_trajectory_points[i].acceleration = joint_trajectory_point.accelerations[i];
+  }
+}
+
+// convert vector of AxisTrajectoryPoint to JointTrajectoryPoint
+void convert_to_joint_trajectory_point_for_joint_limiting(
+  const std::vector<control_msgs::msg::AxisTrajectoryPoint> & axis_trajectory_points,
+  trajectory_msgs::msg::JointTrajectoryPoint & joint_trajectory_point)
+{
+  joint_trajectory_point.positions.clear();
+  joint_trajectory_point.velocities.clear();
+  joint_trajectory_point.accelerations.clear();
+
+  for (size_t i = 0; i < axis_trajectory_points.size(); ++i)
+  {
+    joint_trajectory_point.positions.push_back(axis_trajectory_points[i].position);
+    joint_trajectory_point.velocities.push_back(axis_trajectory_points[i].velocity);
+    if (axis_trajectory_points.size() > i)
+    {
+      joint_trajectory_point.accelerations.push_back(axis_trajectory_points[i].acceleration);
+    }
+  }
+}
+
 }  // namespace
 
 Trajectory::Trajectory()
@@ -346,8 +381,13 @@ std::vector<bool> Trajectory::sample(
 
       if (joint_limiter)
       {
-        // TODO(bijoua29): implement joint limiter
-        // joint_limiters[axis_index]->enforce(previous_state_, output_state, period);
+        trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt, output_state_joint_traj_pt;
+        convert_to_joint_trajectory_point_for_joint_limiting(previous_state_, prev_state_joint_traj_pt);
+        convert_to_joint_trajectory_point_for_joint_limiting(output_state, output_state_joint_traj_pt);
+
+        joint_limiter->enforce(prev_state_joint_traj_pt, output_state_joint_traj_pt, period);
+
+        convert_to_axis_trajectory_points_for_joint_limiting(output_state_joint_traj_pt, output_state);
       }
 
       previous_state_ = output_state;
@@ -399,8 +439,13 @@ std::vector<bool> Trajectory::sample(
 
         if (joint_limiter)
         {
-          // TODO(bijoua29): implement joint limiter
-          // joint_limiters[axis_index]->enforce(previous_state_, output_state, period);
+          trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt, output_state_joint_traj_pt;
+          convert_to_joint_trajectory_point_for_joint_limiting(previous_state_, prev_state_joint_traj_pt);
+          convert_to_joint_trajectory_point_for_joint_limiting(output_state, output_state_joint_traj_pt);
+
+          joint_limiter->enforce(prev_state_joint_traj_pt, output_state_joint_traj_pt, period);
+
+          convert_to_axis_trajectory_points_for_joint_limiting(output_state_joint_traj_pt, output_state);
         }
         previous_state_ = output_state;
         is_valid[axis_index] = true;
@@ -469,8 +514,13 @@ std::vector<bool> Trajectory::sample(
 
     if (joint_limiter)
     {
-      // TODO(bijoua29): implement joint limiter
-      // joint_limiters[axis_index]->enforce(previous_state_, output_state, period);
+      trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt, output_state_joint_traj_pt;
+      convert_to_joint_trajectory_point_for_joint_limiting(previous_state_, prev_state_joint_traj_pt);
+      convert_to_joint_trajectory_point_for_joint_limiting(output_state, output_state_joint_traj_pt);
+
+      joint_limiter->enforce(prev_state_joint_traj_pt, output_state_joint_traj_pt, period);
+
+      convert_to_axis_trajectory_points_for_joint_limiting(output_state_joint_traj_pt, output_state);
     }
   }
   previous_state_ = output_state;

--- a/multi_time_trajectory_controller/src/trajectory.cpp
+++ b/multi_time_trajectory_controller/src/trajectory.cpp
@@ -345,13 +345,6 @@ std::vector<bool> Trajectory::sample(
     const rclcpp::Time first_point_timestamp =
       trajectory_start_time_ + first_point_in_msg.time_from_start;
 
-    auto const tst_ct = trajectory_start_time_.get_clock_type();
-    auto const fpt_ct = first_point_timestamp.get_clock_type();
-    auto const st_ct = sample_time.get_clock_type();
-    (void)tst_ct;
-    (void)fpt_ct;
-    (void)st_ct;
-
     // current time hasn't reached traj time of the first point in the msg yet
     if (sample_time < first_point_timestamp)
     {
@@ -381,13 +374,17 @@ std::vector<bool> Trajectory::sample(
 
       if (joint_limiter)
       {
-        trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt, output_state_joint_traj_pt;
-        convert_to_joint_trajectory_point_for_joint_limiting(previous_state_, prev_state_joint_traj_pt);
-        convert_to_joint_trajectory_point_for_joint_limiting(output_state, output_state_joint_traj_pt);
+        trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt,
+          output_state_joint_traj_pt;
+        convert_to_joint_trajectory_point_for_joint_limiting(
+          previous_state_, prev_state_joint_traj_pt);
+        convert_to_joint_trajectory_point_for_joint_limiting(
+          output_state, output_state_joint_traj_pt);
 
         joint_limiter->enforce(prev_state_joint_traj_pt, output_state_joint_traj_pt, period);
 
-        convert_to_axis_trajectory_points_for_joint_limiting(output_state_joint_traj_pt, output_state);
+        convert_to_axis_trajectory_points_for_joint_limiting(
+          output_state_joint_traj_pt, output_state);
       }
 
       previous_state_ = output_state;
@@ -439,13 +436,17 @@ std::vector<bool> Trajectory::sample(
 
         if (joint_limiter)
         {
-          trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt, output_state_joint_traj_pt;
-          convert_to_joint_trajectory_point_for_joint_limiting(previous_state_, prev_state_joint_traj_pt);
-          convert_to_joint_trajectory_point_for_joint_limiting(output_state, output_state_joint_traj_pt);
+          trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt,
+            output_state_joint_traj_pt;
+          convert_to_joint_trajectory_point_for_joint_limiting(
+            previous_state_, prev_state_joint_traj_pt);
+          convert_to_joint_trajectory_point_for_joint_limiting(
+            output_state, output_state_joint_traj_pt);
 
           joint_limiter->enforce(prev_state_joint_traj_pt, output_state_joint_traj_pt, period);
 
-          convert_to_axis_trajectory_points_for_joint_limiting(output_state_joint_traj_pt, output_state);
+          convert_to_axis_trajectory_points_for_joint_limiting(
+            output_state_joint_traj_pt, output_state);
         }
         previous_state_ = output_state;
         is_valid[axis_index] = true;
@@ -514,13 +515,17 @@ std::vector<bool> Trajectory::sample(
 
     if (joint_limiter)
     {
-      trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt, output_state_joint_traj_pt;
-      convert_to_joint_trajectory_point_for_joint_limiting(previous_state_, prev_state_joint_traj_pt);
-      convert_to_joint_trajectory_point_for_joint_limiting(output_state, output_state_joint_traj_pt);
+      trajectory_msgs::msg::JointTrajectoryPoint prev_state_joint_traj_pt,
+        output_state_joint_traj_pt;
+      convert_to_joint_trajectory_point_for_joint_limiting(
+        previous_state_, prev_state_joint_traj_pt);
+      convert_to_joint_trajectory_point_for_joint_limiting(
+        output_state, output_state_joint_traj_pt);
 
       joint_limiter->enforce(prev_state_joint_traj_pt, output_state_joint_traj_pt, period);
 
-      convert_to_axis_trajectory_points_for_joint_limiting(output_state_joint_traj_pt, output_state);
+      convert_to_axis_trajectory_points_for_joint_limiting(
+        output_state_joint_traj_pt, output_state);
     }
   }
   previous_state_ = output_state;


### PR DESCRIPTION
Integrate joint limiter to MAC
- add creation of joint limiter loader
- add creation of joint limiter
- enforce joint limits in trajectory converting to/from JointTrajectoryPoint as required by saturation joint limiter