### PR TITLE
Fix multi-time trajectory controller failing activate

### DIFF
--- a/multi_time_trajectory_controller/include/multi_time_trajectory_controller/multi_time_trajectory_controller.hpp
+++ b/multi_time_trajectory_controller/include/multi_time_trajectory_controller/multi_time_trajectory_controller.hpp
@@ -336,6 +336,7 @@ private:
   ControllerFeedbackMsg last_odom_feedback_;
   ControllerReferenceMsg last_reference_;
   ControllerReferenceMsg last_reliable_reference_;
+  bool current_state_initialized_{false};
   using JointTrajectoryPoint = control_msgs::msg::AxisTrajectoryPoint;
 
   // Command subscribers and Controller State publisher
@@ -349,6 +350,8 @@ private:
 
   bool contains_interface_type(
     const std::vector<std::string> & interface_type_list, const std::string & interface_type);
+
+  bool initialize_current_state();
 
   void init_hold_position_msg();
 };


### PR DESCRIPTION
Fix multi-time trajectory controller failing activate when feedback is not available during on_activate()
- fix by delaying initialization of current state to update() when feedback is not available during on_activate()