### PR TITLE
Fix for deprecated get_value() method in ros2_control

### DIFF
--- a/multi_time_trajectory_controller/include/multi_time_trajectory_controller/multi_time_trajectory_controller.hpp
+++ b/multi_time_trajectory_controller/include/multi_time_trajectory_controller/multi_time_trajectory_controller.hpp
@@ -305,7 +305,9 @@ protected:
   {
     for (size_t index = 0; index < dof_; ++index)
     {
-      trajectory_point_interface[index].position = axis_interface[index].get().get_value();
+      auto pos = axis_interface[index].get().get_optional();
+      if (!pos) continue;
+      trajectory_point_interface[index].position = *pos;
     }
   };
   template <typename T>
@@ -315,7 +317,9 @@ protected:
   {
     for (size_t index = 0; index < dof_; ++index)
     {
-      trajectory_point_interface[index].velocity = axis_interface[index].get().get_value();
+      auto vel = axis_interface[index].get().get_optional();
+      if (!vel) continue;
+      trajectory_point_interface[index].velocity = *vel;
     }
   };
   template <typename T>
@@ -325,7 +329,9 @@ protected:
   {
     for (size_t index = 0; index < dof_; ++index)
     {
-      trajectory_point_interface[index].acceleration = axis_interface[index].get().get_value();
+      auto acc = axis_interface[index].get().get_optional();
+      if (!acc) continue;
+      trajectory_point_interface[index].acceleration = *acc;
     }
   };
 

--- a/multi_time_trajectory_controller/src/multi_time_trajectory_controller.cpp
+++ b/multi_time_trajectory_controller/src/multi_time_trajectory_controller.cpp
@@ -654,8 +654,12 @@ bool MultiTimeTrajectoryController::read_state_from_command_interfaces(
   auto interface_has_values = [](const auto & joint_interface)
   {
     return std::find_if(
-             joint_interface.begin(), joint_interface.end(), [](const auto & interface)
-             { return std::isnan(interface.get().get_value()); }) == joint_interface.end();
+             joint_interface.begin(), joint_interface.end(),
+             [](const auto & interface)
+             {
+               auto val = interface.get().get_optional();
+               return val && std::isnan(*val);
+             }) == joint_interface.end();
   };
 
   // Assign values from the command interfaces as state
@@ -1309,8 +1313,8 @@ controller_interface::CallbackReturn MultiTimeTrajectoryController::on_deactivat
   {
     if (has_position_command_interface_)
     {
-      if (!axis_command_interface_[0][index].get().set_value(
-            axis_command_interface_[0][index].get().get_value()))
+      auto pos_cmd_val = axis_command_interface_[0][index].get().get_optional();
+      if (pos_cmd_val && !axis_command_interface_[0][index].get().set_value(*pos_cmd_val))
       {
         RCLCPP_WARN_STREAM(
           get_node()->get_logger(), "Failed to set position command interface to current value for "

--- a/multi_time_trajectory_controller/src/trajectory.cpp
+++ b/multi_time_trajectory_controller/src/trajectory.cpp
@@ -217,8 +217,8 @@ void wraparound_joint(
 
 void Trajectory::update(
   std::shared_ptr<control_msgs::msg::MultiAxisTrajectory> multi_axis_trajectory,
-  const std::vector<joint_limits::JointLimits> & joint_limits, const rclcpp::Duration & period,
-  rclcpp::Time const & time)
+  const std::vector<joint_limits::JointLimits> & /*joint_limits*/,
+  const rclcpp::Duration & /*period*/, rclcpp::Time const & time)
 {
   // start by setting the start time of the trajectory if we're supposed to start it right away
   if (rclcpp::Time(multi_axis_trajectory->header.stamp).seconds() == 0.0)
@@ -547,8 +547,8 @@ bool Trajectory::interpolate_between_points(
   const rclcpp::Time & time_a, const control_msgs::msg::AxisTrajectoryPoint & state_a,
   const rclcpp::Time & time_b, const control_msgs::msg::AxisTrajectoryPoint & state_b,
   const rclcpp::Time & sample_time, const bool skip_splines,
-  control_msgs::msg::AxisTrajectoryPoint & output, const rclcpp::Duration & period,
-  control_msgs::msg::AxisTrajectoryPoint & splines_state, std::size_t axis_index)
+  control_msgs::msg::AxisTrajectoryPoint & output, const rclcpp::Duration & /*period*/,
+  control_msgs::msg::AxisTrajectoryPoint & splines_state, std::size_t /*axis_index*/)
 {
   //   RCLCPP_WARN(rclcpp::get_logger("trajectory"), "New iteration");
 

--- a/multi_time_trajectory_controller/test/test_mttc_utils.hpp
+++ b/multi_time_trajectory_controller/test/test_mttc_utils.hpp
@@ -748,11 +748,9 @@ public:
       {
         for (size_t i = 0; i < 3; i++)
         {
-          double val;
-          EXPECT_TRUE(
-            pos_state_interfaces_[i].get_value(val) &&
-            is_same_sign_or_zero(position.at(i) - val, axis_vel_[i]))
-            << "test position point " << position.at(i) << ", position state is " << val
+          auto val = pos_state_interfaces_[i].get_optional();
+          EXPECT_TRUE(val && is_same_sign_or_zero(position.at(i) - *val, axis_vel_[i]))
+            << "test position point " << position.at(i) << ", position state is " << *val
             << ", velocity command is " << axis_vel_[i];
         }
       }
@@ -760,11 +758,9 @@ public:
       {
         for (size_t i = 0; i < 3; i++)
         {
-          double val;
-          EXPECT_TRUE(
-            pos_state_interfaces_[i].get_value(val) &&
-            is_same_sign_or_zero(position.at(i) - val, axis_eff_[i]))
-            << "test position point " << position.at(i) << ", position state is " << val
+          auto val = pos_state_interfaces_[i].get_optional();
+          EXPECT_TRUE(val && is_same_sign_or_zero(position.at(i) - *val, axis_eff_[i]))
+            << "test position point " << position.at(i) << ", position state is " << *val
             << ", effort command is " << axis_eff_[i];
         }
       }


### PR DESCRIPTION
Fix for following deprecation of get_value() method in ros2_control:

warning: ‘bool hardware_interface::Handle::get_value(T&) const [with T = double]’ is deprecated: Use std::optional<T> get_optional() instead to retrieve the value. This method will be removed by the ROS 2 Kilted Kaiju release. [-Wdeprecated-declarations]

Also commented out some unused vars to fix compile warnings
