### PR TITLE
Fix MAC tests

### DIFF
--- a/multi_time_trajectory_controller/src/multi_time_trajectory_controller.cpp
+++ b/multi_time_trajectory_controller/src/multi_time_trajectory_controller.cpp
@@ -92,6 +92,18 @@ controller_interface::CallbackReturn MultiTimeTrajectoryController::on_init()
     }
     else
     {
+      for (size_t i = 0; i < params_.axes_is_angular.size(); ++i)
+      {
+        auto urdf_axis = model.getJoint(params_.axes[i]);
+        if (urdf_axis && urdf_axis->type == urdf::Joint::CONTINUOUS)
+        {
+          RCLCPP_WARN(
+            get_node()->get_logger(), "axis '%s' is of type continuous, use angle_wraparound.",
+            params_.axes[i].c_str());
+          axis_angle_wraparound_[i] = true;
+        }
+        // do nothing if joint is not found in the URDF
+      }
       RCLCPP_DEBUG(get_node()->get_logger(), "Successfully parsed URDF file");
     }
   }
@@ -156,11 +168,6 @@ MultiTimeTrajectoryController::state_interface_configuration() const
 controller_interface::return_type MultiTimeTrajectoryController::update(
   const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  if (get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-  {
-    return controller_interface::return_type::OK;
-  }
-
   // bail if haven't initialized current state and still can't
   if (!current_state_initialized_ && !initialize_current_state())
   {
@@ -799,12 +806,6 @@ controller_interface::CallbackReturn MultiTimeTrajectoryController::on_configure
   const rclcpp_lifecycle::State &)
 {
   const auto logger = get_node()->get_logger();
-
-  if (!param_listener_)
-  {
-    RCLCPP_ERROR(get_node()->get_logger(), "Could not get param listener during configure");
-    return controller_interface::CallbackReturn::ERROR;
-  }
 
   // update the dynamic map parameters
   param_listener_->refresh_dynamic_parameters();

--- a/multi_time_trajectory_controller/src/multi_time_trajectory_controller.cpp
+++ b/multi_time_trajectory_controller/src/multi_time_trajectory_controller.cpp
@@ -66,7 +66,8 @@ controller_interface::CallbackReturn MultiTimeTrajectoryController::on_init()
     params_ = param_listener_->get_params();
 
     joint_limiter_loader_ = std::make_shared<pluginlib::ClassLoader<JointLimiter>>(
-      "joint_limits", "joint_limits::JointLimiterInterface<joint_limits::JointLimits>");
+      "joint_limits",
+      "joint_limits::JointLimiterInterface<trajectory_msgs::msg::JointTrajectoryPoint>");
     RCLCPP_DEBUG(get_node()->get_logger(), "Available joint limiter classes:");
     for (const auto & available_class : joint_limiter_loader_->getDeclaredClasses())
     {

--- a/multi_time_trajectory_controller/test/test_mttc.cpp
+++ b/multi_time_trajectory_controller/test/test_mttc.cpp
@@ -1991,6 +1991,7 @@ TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parame
 TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
 {
   axis_names_ = {"x", "y", "z", "roll", "pitch", "yaw"};
+  axis_is_angular_ = {false, false, false, true, true, true};
   command_axis_names_ = {"command_x",    "command_y",     "command_z",
                          "command_roll", "command_pitch", "command_yaw"};
   command_interface_types_ = {"position", "velocity"};
@@ -2273,6 +2274,7 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
 TEST_F(TrajectoryControllerTest, test_joint_limiter_active_but_no_joint_limiting)
 {
   axis_names_ = {"x", "y", "z", "roll", "pitch", "yaw"};
+  axis_is_angular_ = {false, false, false, true, true, true};
   command_axis_names_ = {"command_x",    "command_y",     "command_z",
                          "command_roll", "command_pitch", "command_yaw"};
   command_interface_types_ = {"position", "velocity"};
@@ -2423,6 +2425,7 @@ TEST_F(TrajectoryControllerTest, test_joint_limiter_active_but_no_joint_limiting
 TEST_F(TrajectoryControllerTest, test_joint_limiter_active_and_joint_limiting)
 {
   axis_names_ = {"x", "y", "z", "roll", "pitch", "yaw"};
+  axis_is_angular_ = {false, false, false, true, true, true};
   command_axis_names_ = {"command_x",    "command_y",     "command_z",
                          "command_roll", "command_pitch", "command_yaw"};
   command_interface_types_ = {"position", "velocity"};

--- a/multi_time_trajectory_controller/test/test_mttc.cpp
+++ b/multi_time_trajectory_controller/test/test_mttc.cpp
@@ -690,7 +690,7 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_angle_wraparound)
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double k_p = 10.0;
   std::vector<rclcpp::Parameter> params = {};
-  // params.emplace_back("axes_is_angular", std::vector<bool>{true, true, true});
+  params.emplace_back("axes_is_angular", std::vector<bool>{true, true, true});
   SetUpAndActivateTrajectoryController(
     executor, params, true, k_p, 0.0, INITIAL_POS_AXES, INITIAL_VEL_AXES, INITIAL_ACC_AXES,
     INITIAL_EFF_AXES, test_mttc::urdf_rrrbot_continuous);

--- a/multi_time_trajectory_controller/test/test_mttc.cpp
+++ b/multi_time_trajectory_controller/test/test_mttc.cpp
@@ -22,6 +22,7 @@
 #include <thread>
 #include <vector>
 
+#include <rclcpp/duration.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/parameter.hpp>
 #include <rclcpp/parameter_value.hpp>
@@ -2028,7 +2029,7 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
   traj_controller_->wait_for_trajectory(executor);
 
   // now test that we haven't moved
-  waitAndCompareState(
+  auto end_time = waitAndCompareState(
     expected_actual, expected_desired, executor, chrono_duration * freq_Hz, 0.1,
     rclcpp::Time(0, 0, RCL_STEADY_TIME), true);
   positions.clear();
@@ -2074,9 +2075,8 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
   publish(dur, positions, rclcpp::Time(0, 0, RCL_STEADY_TIME), {}, velocities);
   traj_controller_->wait_for_trajectory(executor);
 
-  waitAndCompareState(
-    expected_actual, expected_desired, executor, chrono_duration * freq_Hz, 0.1,
-    rclcpp::Time(0, 0, RCL_STEADY_TIME), true);
+  end_time = waitAndCompareState(
+    expected_actual, expected_desired, executor, chrono_duration * freq_Hz, 0.1, end_time, true);
   positions.clear();
   velocities.clear();
   expected_actual.clear();
@@ -2104,9 +2104,8 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
 
   traj_controller_->wait_for_trajectory(executor);
 
-  waitAndCompareState(
-    expected_actual, expected_desired, executor, chrono_duration * freq_Hz, 0.1,
-    rclcpp::Time(0, 0, RCL_STEADY_TIME), true);
+  end_time = waitAndCompareState(
+    expected_actual, expected_desired, executor, chrono_duration * freq_Hz, 0.1, end_time, true);
   positions.clear();
   velocities.clear();
   expected_actual.clear();
@@ -2131,7 +2130,9 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
   request->positions = {final_pos[0], final_pos[1]};
   request->velocities = {0, 0};
   request->accelerations = {0, 0};
-  send_reset_request(request, executor);
+  end_time = send_reset_request(end_time, request, executor);
+
+  traj_controller_->wait_for_trajectory(executor);
 
   // now axis_multiplexer sends all nans for x and y
   positions = {freq_Hz, final_pos};
@@ -2157,9 +2158,9 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
 
   traj_controller_->wait_for_trajectory(executor);
 
-  waitAndCompareState(
-    expected_actual, expected_desired, executor, chrono_duration * (3 * freq_Hz / 2), 0.1,
-    rclcpp::Time(0, 0, RCL_STEADY_TIME), true);
+  end_time = waitAndCompareState(
+    expected_actual, expected_desired, executor, chrono_duration * (3 * freq_Hz / 2), 0.1, end_time,
+    true);
   positions.clear();
   velocities.clear();
   expected_actual.clear();
@@ -2186,9 +2187,9 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
 
   traj_controller_->wait_for_trajectory(executor);
 
-  waitAndCompareState(
-    expected_actual, expected_desired, executor, chrono_duration * (3 * freq_Hz / 2), 0.1,
-    rclcpp::Time(0, 0, RCL_STEADY_TIME), true);
+  end_time = waitAndCompareState(
+    expected_actual, expected_desired, executor, chrono_duration * (3 * freq_Hz / 2), 0.1, end_time,
+    true);
   positions.clear();
   velocities.clear();
   expected_actual.clear();
@@ -2224,18 +2225,12 @@ TEST_F(TrajectoryControllerTest, open_closed_enable_disable)
 
   traj_controller_->wait_for_trajectory(executor);
 
-  waitAndCompareState(
-    expected_actual, expected_desired, executor, chrono_duration * freq_Hz, 0.1,
-    rclcpp::Time(0, 0, RCL_STEADY_TIME), true);
+  end_time = waitAndCompareState(
+    expected_actual, expected_desired, executor, chrono_duration * freq_Hz, 0.1, end_time, true);
   positions.clear();
   velocities.clear();
   expected_actual.clear();
   expected_desired.clear();
-
-  // If I disable closed-loop control for X-Y, and try to move X-Y in
-  // open-loop with joystick again on MAC, it doesn't move. If I move the joystick in a different
-  // axes e.g. heading, it works fine. I have to confirm again but Z doesn't work anymore though
-  // either on MAC.
 }
 
 TEST_F(TrajectoryControllerTest, test_joint_limiter_active_but_no_joint_limiting)

--- a/multi_time_trajectory_controller/test/test_mttc.cpp
+++ b/multi_time_trajectory_controller/test/test_mttc.cpp
@@ -15,18 +15,16 @@
 #include <gtest/gtest.h>
 #include <rcl/time.h>
 #include <cmath>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
 
 #include <chrono>
 #include <cstddef>
 #include <limits>
-#include <rclcpp/parameter_value.hpp>
 #include <thread>
 #include <vector>
 
 #include <rclcpp/node.hpp>
 #include <rclcpp/parameter.hpp>
+#include <rclcpp/parameter_value.hpp>
 #include "control_msgs/msg/axis_trajectory_point.hpp"
 #include "control_msgs/msg/multi_axis_trajectory.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -2265,7 +2263,7 @@ TEST_F(TrajectoryControllerTest, test_joint_limiter_active_but_no_joint_limiting
     {"use_feedback", true},
     {"allow_integration_in_goal_trajectories", true},
     {"hold_last_velocity", true},
-    {"joint_limiter_type", "joint_limits/JointInterfacesSaturationLimiter"},
+    {"joint_limiter_type", "joint_limits/JointTrajectoryPointSaturationLimiter"},
     // joint limits for x
     {"joint_limits.x.has_position_limits", false},
     {"joint_limits.x.has_velocity_limits", true},
@@ -2416,7 +2414,7 @@ TEST_F(TrajectoryControllerTest, test_joint_limiter_active_and_joint_limiting)
     {"use_feedback", true},
     {"allow_integration_in_goal_trajectories", true},
     {"hold_last_velocity", true},
-    {"joint_limiter_type", "joint_limits/JointInterfacesSaturationLimiter"},
+    {"joint_limiter_type", "joint_limits/JointTrajectoryPointSaturationLimiter"},
     // joint limits for x
     {"joint_limits.x.has_position_limits", false},
     {"joint_limits.x.has_velocity_limits", true},

--- a/multi_time_trajectory_controller/test/test_mttc.cpp
+++ b/multi_time_trajectory_controller/test/test_mttc.cpp
@@ -14,12 +14,14 @@
 
 #include <gtest/gtest.h>
 #include <rcl/time.h>
+#include <cmath>
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Geometry>
 
 #include <chrono>
 #include <cstddef>
 #include <limits>
+#include <rclcpp/parameter_value.hpp>
 #include <thread>
 #include <vector>
 
@@ -36,39 +38,6 @@
 using lifecycle_msgs::msg::State;
 using test_mttc::TrajectoryControllerTest;
 using test_mttc::TrajectoryControllerTestParameterized;
-
-TEST_P(TrajectoryControllerTestParameterized, configure_state_ignores_commands)
-{
-  rclcpp::executors::MultiThreadedExecutor executor;
-  SetUpTrajectoryController(executor);
-  traj_controller_->get_node()->set_parameter(
-    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true));
-
-  const auto state = traj_controller_->get_node()->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-
-  // send msg
-  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
-  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
-  // *INDENT-OFF*
-  std::vector<std::vector<double>> points{
-    {{3.3, 4.4, 5.5}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
-  std::vector<std::vector<double>> points_velocity{
-    {{0.01, 0.01, 0.01}}, {{0.05, 0.05, 0.05}}, {{0.06, 0.06, 0.06}}};
-  // *INDENT-ON*
-  publish(time_from_start, points, rclcpp::Time(), {}, points_velocity);
-  traj_controller_->wait_for_trajectory(executor);
-
-  traj_controller_->update(
-    rclcpp::Time(static_cast<uint64_t>(0.5 * 1e9)), rclcpp::Duration::from_seconds(0.5));
-
-  // hw position == 0 because controller is not activated
-  EXPECT_EQ(0.0, axis_pos_[0]);
-  EXPECT_EQ(0.0, axis_pos_[1]);
-  EXPECT_EQ(0.0, axis_pos_[2]);
-
-  executor.cancel();
-}
 
 TEST_P(TrajectoryControllerTestParameterized, check_interface_names)
 {
@@ -139,7 +108,6 @@ TEST_P(TrajectoryControllerTestParameterized, cleanup)
 
   auto state = traj_controller_->get_node()->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
 
   state = traj_controller_->get_node()->cleanup();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
@@ -211,8 +179,8 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   std::vector<double> deactivated_positions{axis_pos_[0], axis_pos_[1], axis_pos_[2]};
   state = traj_controller_->get_node()->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+
   // it should be holding the current point
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.1));
   expectHoldingPointDeactivated(deactivated_positions);
 
   // reactivate
@@ -432,6 +400,7 @@ TEST_P(TrajectoryControllerTestParameterized, compute_error_angle_wraparound_tru
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   std::vector<rclcpp::Parameter> params = {};
+  params.emplace_back("axes_is_angular", std::vector<bool>{true, true, true});
   SetUpAndActivateTrajectoryController(
     executor, params, true, 0.0, 1.0, INITIAL_POS_AXES, INITIAL_VEL_AXES, INITIAL_ACC_AXES,
     INITIAL_EFF_AXES, test_mttc::urdf_rrrbot_continuous);
@@ -722,6 +691,7 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_angle_wraparound)
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double k_p = 10.0;
   std::vector<rclcpp::Parameter> params = {};
+  // params.emplace_back("axes_is_angular", std::vector<bool>{true, true, true});
   SetUpAndActivateTrajectoryController(
     executor, params, true, k_p, 0.0, INITIAL_POS_AXES, INITIAL_VEL_AXES, INITIAL_ACC_AXES,
     INITIAL_EFF_AXES, test_mttc::urdf_rrrbot_continuous);
@@ -761,20 +731,19 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_angle_wraparound)
   // are the correct reference position used?
   EXPECT_NEAR(points[0][0], state_reference[0].position, COMMON_THRESHOLD);
   EXPECT_NEAR(points[0][1], state_reference[1].position, COMMON_THRESHOLD);
-  EXPECT_NEAR(points[0][2], state_reference[2].position, COMMON_THRESHOLD);
+  EXPECT_NEAR(points[0][2] - 2 * M_PI, state_reference[2].position, COMMON_THRESHOLD);
 
   // is error.position[2] wrapped around?
   EXPECT_NEAR(state_error[0].position, state_reference[0].position - INITIAL_POS_AXES[0], EPS);
   EXPECT_NEAR(state_error[1].position, state_reference[1].position - INITIAL_POS_AXES[1], EPS);
-  EXPECT_NEAR(
-    state_error[2].position, state_reference[2].position - INITIAL_POS_AXES[2] - 2 * M_PI, EPS);
+  EXPECT_NEAR(state_error[2].position, state_reference[2].position - INITIAL_POS_AXES[2], EPS);
 
   if (traj_controller_->has_position_command_interface())
   {
     // check command interface
     EXPECT_NEAR(points[0][0], axis_pos_[0], COMMON_THRESHOLD);
     EXPECT_NEAR(points[0][1], axis_pos_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(points[0][2], axis_pos_[2], COMMON_THRESHOLD);
+    EXPECT_NEAR(points[0][2] - 2 * M_PI, axis_pos_[2], COMMON_THRESHOLD);
   }
 
   if (traj_controller_->has_velocity_command_interface())
@@ -792,7 +761,7 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_angle_wraparound)
       // is error of position[2] wrapped around?
       EXPECT_GT(0.0, axis_vel_[2]);  // direction change because of angle wrap
       EXPECT_NEAR(
-        k_p * (state_reference[2].position - INITIAL_POS_AXES[2] - 2 * M_PI), axis_vel_[2],
+        k_p * (state_reference[2].position - INITIAL_POS_AXES[2]), axis_vel_[2],
         k_p * COMMON_THRESHOLD);
     }
     else
@@ -818,7 +787,7 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_angle_wraparound)
     // is error of position[2] wrapped around?
     EXPECT_GT(0.0, axis_eff_[2]);
     EXPECT_NEAR(
-      k_p * (state_reference[2].position - INITIAL_POS_AXES[2] - 2 * M_PI), axis_eff_[2],
+      k_p * (state_reference[2].position - INITIAL_POS_AXES[2]), axis_eff_[2],
       k_p * COMMON_THRESHOLD);
   }
 
@@ -2296,7 +2265,7 @@ TEST_F(TrajectoryControllerTest, test_joint_limiter_active_but_no_joint_limiting
     {"use_feedback", true},
     {"allow_integration_in_goal_trajectories", true},
     {"hold_last_velocity", true},
-    {"joint_limiter_type", "joint_limits/JointSaturationLimiter"},
+    {"joint_limiter_type", "joint_limits/JointInterfacesSaturationLimiter"},
     // joint limits for x
     {"joint_limits.x.has_position_limits", false},
     {"joint_limits.x.has_velocity_limits", true},
@@ -2447,7 +2416,7 @@ TEST_F(TrajectoryControllerTest, test_joint_limiter_active_and_joint_limiting)
     {"use_feedback", true},
     {"allow_integration_in_goal_trajectories", true},
     {"hold_last_velocity", true},
-    {"joint_limiter_type", "joint_limits/JointSaturationLimiter"},
+    {"joint_limiter_type", "joint_limits/JointInterfacesSaturationLimiter"},
     // joint limits for x
     {"joint_limits.x.has_position_limits", false},
     {"joint_limits.x.has_velocity_limits", true},

--- a/multi_time_trajectory_controller/test/test_mttc_utils.hpp
+++ b/multi_time_trajectory_controller/test/test_mttc_utils.hpp
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <memory>
+#include <ros2_control_test_assets/ros2_control_test_assets/descriptions.hpp>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -34,6 +35,7 @@
 #include "control_msgs/msg/multi_axis_trajectory.hpp"
 #include "control_msgs/msg/multi_time_trajectory_controller_state.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 #include "multi_time_trajectory_controller/multi_time_trajectory_controller.hpp"
 
 namespace
@@ -219,16 +221,33 @@ public:
     create_reset_dofs_service_client();
   }
 
-  virtual void TearDown()
+  void DeactivateTrajectoryController()
   {
+    if (traj_controller_)
+    {
+      if (
+        traj_controller_->get_lifecycle_state().id() ==
+        lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+      {
+        EXPECT_EQ(
+          traj_controller_->get_node()->deactivate().id(),
+          lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+      }
+    }
+  }
+
+  void TearDown() override
+  {
+    DeactivateTrajectoryController();
     shutdown_ = true;
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    traj_controller_.reset();
     traj_gen_sync_thread_.join();
   }
 
   void SetUpTrajectoryController(
     rclcpp::Executor & executor, const std::vector<rclcpp::Parameter> & parameters = {},
-    const std::string & urdf = "")
+    const std::string & urdf = ros2_control_test_assets::minimal_robot_urdf)
   {
     auto has_nonzero_vel_param =
       std::find_if(
@@ -269,7 +288,8 @@ public:
   }
 
   controller_interface::return_type SetUpTrajectoryControllerLocal(
-    const std::vector<rclcpp::Parameter> & parameters = {}, const std::string & urdf = "")
+    const std::vector<rclcpp::Parameter> & parameters = {},
+    const std::string & urdf = ros2_control_test_assets::minimal_robot_urdf)
   {
     traj_controller_ = std::make_shared<TestableMultiTimeTrajectoryController>();
 
@@ -311,7 +331,8 @@ public:
     const std::vector<double> & initial_pos_axes = INITIAL_POS_AXES,
     const std::vector<double> & initial_vel_axes = INITIAL_VEL_AXES,
     const std::vector<double> & initial_acc_axes = INITIAL_ACC_AXES,
-    const std::vector<double> & initial_eff_axes = INITIAL_EFF_AXES, const std::string & urdf = "")
+    const std::vector<double> & initial_eff_axes = INITIAL_EFF_AXES,
+    const std::string & urdf = ros2_control_test_assets::minimal_robot_urdf)
   {
     auto has_nonzero_vel_param =
       std::find_if(
@@ -944,6 +965,8 @@ public:
     command_interface_types_ = std::get<0>(GetParam());
     state_interface_types_ = std::get<1>(GetParam());
   }
+
+  virtual void TearDown() { TrajectoryControllerTest::TearDown(); }
 
   static void TearDownTestCase() { TrajectoryControllerTest::TearDownTestCase(); }
 };

--- a/multi_time_trajectory_controller/test/test_mttc_utils.hpp
+++ b/multi_time_trajectory_controller/test/test_mttc_utils.hpp
@@ -21,7 +21,6 @@
 
 #include <chrono>
 #include <memory>
-#include <ros2_control_test_assets/ros2_control_test_assets/descriptions.hpp>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -31,6 +30,7 @@
 
 #include <rclcpp/executor.hpp>
 #include <rclcpp/future_return_code.hpp>
+#include <ros2_control_test_assets/ros2_control_test_assets/descriptions.hpp>
 #include "control_msgs/msg/axis_trajectory_point.hpp"
 #include "control_msgs/msg/multi_axis_trajectory.hpp"
 #include "control_msgs/msg/multi_time_trajectory_controller_state.hpp"
@@ -595,7 +595,7 @@ public:
   }
 
   /**
-   * @brief a wrapper for update() method of JTC, running synchronously with the clock
+   * @brief a wrapper for update() method of MAC, running synchronously with the clock
    * @param wait_time - the time span for updating the controller
    * @param update_rate - the rate at which the controller is updated
    *
@@ -621,7 +621,7 @@ public:
   }
 
   /**
-   * @brief a wrapper for update() method of JTC, running asynchronously from the clock
+   * @brief a wrapper for update() method of MAC, running asynchronously from the clock
    * @return the time at which the update finished
    * @param wait_time - the time span for updating the controller
    * @param start_time - the time at which the update should start

--- a/multi_time_trajectory_controller/test/test_mttc_utils.hpp
+++ b/multi_time_trajectory_controller/test/test_mttc_utils.hpp
@@ -189,6 +189,7 @@ public:
     controller_name_ = "test_multi_axis_controller";
 
     axis_names_ = {"axis1", "axis2", "axis3"};
+    axis_is_angular_ = {false, false, false};
     command_axis_names_ = {
       "following_controller/axis1", "following_controller/axis2", "following_controller/axis3"};
     axis_pos_.resize(axis_names_.size(), 0.0);
@@ -275,6 +276,7 @@ public:
     auto node_options = rclcpp::NodeOptions();
     std::vector<rclcpp::Parameter> parameter_overrides;
     parameter_overrides.push_back(rclcpp::Parameter("axes", axis_names_));
+    parameter_overrides.push_back(rclcpp::Parameter("axes_is_angular", axis_is_angular_));
     parameter_overrides.push_back(
       rclcpp::Parameter("command_interfaces", command_interface_types_));
     parameter_overrides.push_back(rclcpp::Parameter("state_interfaces", state_interface_types_));
@@ -845,6 +847,7 @@ public:
   std::string controller_name_;
 
   std::vector<std::string> axis_names_;
+  std::vector<bool> axis_is_angular_;
   std::vector<std::string> command_axis_names_;
   std::vector<std::string> command_interface_types_;
   std::vector<std::string> state_interface_types_;

--- a/multi_time_trajectory_controller/test/test_mttc_utils.hpp
+++ b/multi_time_trajectory_controller/test/test_mttc_utils.hpp
@@ -186,7 +186,7 @@ class TrajectoryControllerTest : public ::testing::Test
 public:
   static void SetUpTestCase() { rclcpp::init(0, nullptr); }
 
-  virtual void SetUp()
+  void SetUp() override
   {
     controller_name_ = "test_multi_axis_controller";
 
@@ -664,7 +664,7 @@ public:
         executor->spin_some();
       }
     }
-    return end_time;
+    return time_counter;
   }
 
   rclcpp::Time waitAndCompareState(
@@ -894,17 +894,18 @@ public:
     bool closed_loop_position_enabled;
   };
 
-  bool send_reset_request(
-    std::shared_ptr<control_msgs::srv::ResetDofs::Request> request, rclcpp::Executor & executor)
+  rclcpp::Time send_reset_request(
+    rclcpp::Time start_time, std::shared_ptr<control_msgs::srv::ResetDofs::Request> request,
+    rclcpp::Executor & executor)
   {
     if (!traj_gen_available_)
     {
       throw std::runtime_error("Reset dofs service not yet available.");
     }
     auto result = traj_gen_reset_dofs_client_->async_send_request(request);
-    auto retval = executor.spin_until_future_complete(result, std::chrono::seconds(1));
+    executor.spin_until_future_complete(result, std::chrono::seconds(1));
 
-    return retval == rclcpp::FutureReturnCode::SUCCESS;
+    return updateControllerAsync(rclcpp::Duration::from_seconds(0.2), start_time);
   }
   void create_reset_dofs_service_client()
   {


### PR DESCRIPTION
Fixes breakages in MAC tests due to 

- Joint limiters interface/name change
- Upstream change causing dangling references on destruction (most of the failures were from this)
- Upstream change with angle wrapping
- Reset dofs test being broken (may have already been broken, doesn't seem to be due to upstream changes); this is mostly just not using the system clock in the test, instead using the end time variable




